### PR TITLE
Add a DRF serializer

### DIFF
--- a/django_warnings/serializers.py
+++ b/django_warnings/serializers.py
@@ -1,0 +1,64 @@
+from django.contrib.contenttypes.models import ContentType
+
+from rest_framework import serializers
+
+from .models import Warning
+
+
+class WarningSerializer(serializers.Serializer):
+    """
+    This will be the Serializer normally imported outside the library
+
+    It uses WarningModelSerializer internally to generate the final response
+    """
+
+    def __init__(self, *args, **kwargs):
+
+        # Desired fields are kept and will be pass to WarningModelSerializer
+        self.warning_fields = kwargs.pop('fields', [])
+
+        # On the `to_native` method, we want to receive the parent object
+        # instead of just the `warnings` field
+        kwargs['source'] = '*'
+        kwargs['read_only'] = True
+
+        super(WarningSerializer, self).__init__(*args, **kwargs)
+
+    def to_native(self, obj):
+
+        # Trigger the Warnings generation
+        obj.warnings
+
+        # Fetch generated Warnings
+        warnings = Warning.objects.filter(
+            content_type=ContentType.objects.get_for_model(obj),
+            object_id=obj.id
+        )
+        return WarningModelSerializer(
+            warnings, many=True, fields=self.warning_fields).data
+
+
+class WarningModelSerializer(serializers.ModelSerializer):
+    """
+    A ModelSerializer for the Warning model
+
+    It allows to specify which fields to use at the point of initializing it
+    """
+
+    class Meta:
+        model = Warning
+        fields = ('id', 'content_type', 'object_id', 'subject', 'message',
+                  'first_generated', 'last_generated',
+                  'acknowledged', 'last_acknowledger', 'last_acknowledged')
+
+    def __init__(self, *args, **kwargs):
+        fields = kwargs.pop('fields', [])
+
+        super(WarningModelSerializer, self).__init__(*args, **kwargs)
+
+        # Drop any fields that are not specified in the `fields` argument.
+        # Copied from an example on DRF documentation.
+        allowed = set(fields)
+        existing = set(self.fields.keys())
+        for field_name in existing - allowed:
+            self.fields.pop(field_name)

--- a/tests/models.py
+++ b/tests/models.py
@@ -3,7 +3,7 @@ from django.db import models
 from django_warnings.mixins import WarningsMixin
 
 
-class TestWarningsModel(WarningsMixin, models.Model):
+class WarningsGeneratingModel(WarningsMixin, models.Model):
     """
     A Model for testing the warnings system
     """

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -13,5 +13,5 @@ def flake8():
 def nose():
     from django_nose.runner import NoseTestSuiteRunner
     test_runner = NoseTestSuiteRunner(verbosity=1)
-    failures = test_runner.run_tests(['tests'])
+    failures = test_runner.run_tests(['-s', 'tests'])
     return failures

--- a/tests/unit/test_warnings.py
+++ b/tests/unit/test_warnings.py
@@ -3,42 +3,28 @@ from datetime import timedelta
 from django.test import TestCase
 from django.utils import timezone
 
-from rest_framework import serializers
-
 from django_warnings.models import Warning
-from ..models import TestWarningsModel
-
-
-class TestSerializer(serializers.ModelSerializer):
-
-    warnings = serializers.Field()
-
-    class Meta:
-        model = TestWarningsModel
-        fields = ('name', 'warnings',)
+from ..models import WarningsGeneratingModel
 
 
 class WarningsMixinTest(TestCase):
 
     def test_warnings_property_contains_warnings(self):
-        warning_model = TestWarningsModel.objects.create()
+        """
+        Make a model generate a Warning and check the result
+        """
+        warning_model = WarningsGeneratingModel.objects.create()
 
         self.assertTrue(hasattr(warning_model, 'warnings'))
         self.assertTrue(
             warning_model.warning_message in warning_model.warnings
         )
 
-    def test_serializer_returns_warnings(self):
-        warning_model = TestWarningsModel.objects.create()
-        data = TestSerializer(warning_model).data
-
-        self.assertEqual(data['warnings'][0], warning_model.warning_message)
-
     def test_warnings_are_stored_into_database(self):
         """
         Instantiate a model reporting warnings, it generates a Warning object
         """
-        warning_model = TestWarningsModel.objects.create()
+        warning_model = WarningsGeneratingModel.objects.create()
 
         warnings = warning_model.warnings
         stored_warning = Warning.objects.all()[0]
@@ -51,7 +37,7 @@ class WarningsMixinTest(TestCase):
         """
         Any stored Warning references the class and method that generated it
         """
-        warning_model = TestWarningsModel.objects.create()
+        warning_model = WarningsGeneratingModel.objects.create()
 
         warning_model.warnings
         warning = Warning.objects.all()[0]
@@ -63,7 +49,7 @@ class WarningsMixinTest(TestCase):
         """
         Any stored Warning references its first and last occurrence
         """
-        warning_model = TestWarningsModel.objects.create()
+        warning_model = WarningsGeneratingModel.objects.create()
 
         warning_model.warnings
         warning = Warning.objects.all()[0]
@@ -77,7 +63,7 @@ class WarningsMixinTest(TestCase):
         """
         New occurrences increase the `last_generated` field
         """
-        warning_model = TestWarningsModel.objects.create()
+        warning_model = WarningsGeneratingModel.objects.create()
 
         before = timezone.now()
         warning_model.warnings
@@ -95,7 +81,7 @@ class WarningsMixinTest(TestCase):
         """
         Any stored Warning allows to retrieve the original object causing it
         """
-        warning_model = TestWarningsModel.objects.create()
+        warning_model = WarningsGeneratingModel.objects.create()
 
         warning_model.warnings
         warning = Warning.objects.all()[0]
@@ -108,7 +94,7 @@ class WarningsMixinTest(TestCase):
         """
         Any stored Warning is not acknowledged when first generated
         """
-        warning_model = TestWarningsModel.objects.create()
+        warning_model = WarningsGeneratingModel.objects.create()
 
         warning_model.warnings
         warning = Warning.objects.all()[0]
@@ -124,7 +110,7 @@ class WarningsMixinTest(TestCase):
         A Warning can be acknowledged, then it gets related fields filled
         """
         user_id = 3
-        warning_model = TestWarningsModel.objects.create()
+        warning_model = WarningsGeneratingModel.objects.create()
         warning_model.warnings
         warning = Warning.objects.all()[0]
 
@@ -140,7 +126,7 @@ class WarningsMixinTest(TestCase):
         """
         A Warning is acknowledged automatically by not specifying a `user_id`
         """
-        warning_model = TestWarningsModel.objects.create()
+        warning_model = WarningsGeneratingModel.objects.create()
         warning_model.warnings
         warning = Warning.objects.all()[0]
 

--- a/tests/unit/test_warnings.py
+++ b/tests/unit/test_warnings.py
@@ -13,20 +13,20 @@ class WarningsMixinTest(TestCase):
         """
         Make a model generate a Warning and check the result
         """
-        warning_model = WarningsGeneratingModel.objects.create()
+        warning_object = WarningsGeneratingModel.objects.create()
 
-        self.assertTrue(hasattr(warning_model, 'warnings'))
+        self.assertTrue(hasattr(warning_object, 'warnings'))
         self.assertTrue(
-            warning_model.warning_message in warning_model.warnings
+            warning_object.warning_message in warning_object.warnings
         )
 
     def test_warnings_are_stored_into_database(self):
         """
         Instantiate a model reporting warnings, it generates a Warning object
         """
-        warning_model = WarningsGeneratingModel.objects.create()
+        warning_object = WarningsGeneratingModel.objects.create()
 
-        warnings = warning_model.warnings
+        warnings = warning_object.warnings
         stored_warning = Warning.objects.all()[0]
 
         self.assertEqual(len(warnings), 1)
@@ -37,9 +37,9 @@ class WarningsMixinTest(TestCase):
         """
         Any stored Warning references the class and method that generated it
         """
-        warning_model = WarningsGeneratingModel.objects.create()
+        warning_object = WarningsGeneratingModel.objects.create()
 
-        warning_model.warnings
+        warning_object.warnings
         warning = Warning.objects.all()[0]
 
         self.assertEqual(Warning.objects.count(), 1)
@@ -49,9 +49,9 @@ class WarningsMixinTest(TestCase):
         """
         Any stored Warning references its first and last occurrence
         """
-        warning_model = WarningsGeneratingModel.objects.create()
+        warning_object = WarningsGeneratingModel.objects.create()
 
-        warning_model.warnings
+        warning_object.warnings
         warning = Warning.objects.all()[0]
 
         self.assertEqual(Warning.objects.count(), 1)
@@ -63,11 +63,11 @@ class WarningsMixinTest(TestCase):
         """
         New occurrences increase the `last_generated` field
         """
-        warning_model = WarningsGeneratingModel.objects.create()
+        warning_object = WarningsGeneratingModel.objects.create()
 
         before = timezone.now()
-        warning_model.warnings
-        warning_model.warnings
+        warning_object.warnings
+        warning_object.warnings
         after = timezone.now()
         warning = Warning.objects.all()[0]
 
@@ -81,22 +81,22 @@ class WarningsMixinTest(TestCase):
         """
         Any stored Warning allows to retrieve the original object causing it
         """
-        warning_model = WarningsGeneratingModel.objects.create()
+        warning_object = WarningsGeneratingModel.objects.create()
 
-        warning_model.warnings
+        warning_object.warnings
         warning = Warning.objects.all()[0]
         original_object = warning.content_object
 
         self.assertEqual(Warning.objects.count(), 1)
-        self.assertEqual(original_object, warning_model)
+        self.assertEqual(original_object, warning_object)
 
     def test_stored_warning_is_unacknowledged_by_default(self):
         """
         Any stored Warning is not acknowledged when first generated
         """
-        warning_model = WarningsGeneratingModel.objects.create()
+        warning_object = WarningsGeneratingModel.objects.create()
 
-        warning_model.warnings
+        warning_object.warnings
         warning = Warning.objects.all()[0]
 
         self.assertEqual(Warning.objects.count(), 1)
@@ -110,8 +110,8 @@ class WarningsMixinTest(TestCase):
         A Warning can be acknowledged, then it gets related fields filled
         """
         user_id = 3
-        warning_model = WarningsGeneratingModel.objects.create()
-        warning_model.warnings
+        warning_object = WarningsGeneratingModel.objects.create()
+        warning_object.warnings
         warning = Warning.objects.all()[0]
 
         warning.acknowledge(user_id)
@@ -126,8 +126,8 @@ class WarningsMixinTest(TestCase):
         """
         A Warning is acknowledged automatically by not specifying a `user_id`
         """
-        warning_model = WarningsGeneratingModel.objects.create()
-        warning_model.warnings
+        warning_object = WarningsGeneratingModel.objects.create()
+        warning_object.warnings
         warning = Warning.objects.all()[0]
 
         warning.acknowledge()

--- a/tests/unit/test_warnings_serializer.py
+++ b/tests/unit/test_warnings_serializer.py
@@ -21,11 +21,11 @@ class WarningsSerializerTest(TestCase):
         """
         Serialize a model with Warnings associated to it
         """
-        warning_model = WarningsGeneratingModel.objects.create()
-        data = WarningsGeneratingSerializer(warning_model).data
+        warning_object = WarningsGeneratingModel.objects.create()
+        data = WarningsGeneratingSerializer(warning_object).data
 
         self.assertEqual(data['warnings'][0]['message'],
-                         warning_model.warning_message)
+                         warning_object.warning_message)
 
     def test_serialize_queryset_returns_warnings(self):
         """
@@ -35,8 +35,8 @@ class WarningsSerializerTest(TestCase):
         for _ in xrange(number_of_instances):
             WarningsGeneratingModel.objects.create()
 
-        warning_models = WarningsGeneratingModel.objects.all()
-        data = WarningsGeneratingSerializer(warning_models, many=True).data
+        warning_objects = WarningsGeneratingModel.objects.all()
+        data = WarningsGeneratingSerializer(warning_objects, many=True).data
 
         self.assertEqual(len(data), number_of_instances)
         for element in data:
@@ -54,8 +54,8 @@ class WarningsSerializerTest(TestCase):
                 model = WarningsGeneratingModel
                 fields = ('name', 'warnings',)
 
-        warning_model = WarningsGeneratingModel.objects.create()
-        data = SubjectSerializer(warning_model).data
+        warning_object = WarningsGeneratingModel.objects.create()
+        data = SubjectSerializer(warning_object).data
         warnings = data['warnings']
 
         self.assertEqual(len(warnings), 1)
@@ -78,10 +78,10 @@ class WarningsSerializerTest(TestCase):
                 model = WarningsGeneratingModel
                 fields = ('name', 'warnings',)
 
-        warning_model = WarningsGeneratingModel.objects.create()
-        data = FullSerializer(warning_model).data
+        warning_object = WarningsGeneratingModel.objects.create()
+        data = FullSerializer(warning_object).data
         warnings = data['warnings']
 
         self.assertEqual(len(warnings), 1)
         self.assertEqual(set(warnings[0].keys()), set(all_fields))
-        self.assertEqual(warnings[0]['object_id'], warning_model.id)
+        self.assertEqual(warnings[0]['object_id'], warning_object.id)

--- a/tests/unit/test_warnings_serializer.py
+++ b/tests/unit/test_warnings_serializer.py
@@ -83,5 +83,5 @@ class WarningsSerializerTest(TestCase):
         warnings = data['warnings']
 
         self.assertEqual(len(warnings), 1)
-        self.assertEqual(set(warnings[0].keys()), set(all_fields))
+        self.assertEqual(sorted(warnings[0].keys()), sorted(all_fields))
         self.assertEqual(warnings[0]['object_id'], warning_object.id)

--- a/tests/unit/test_warnings_serializer.py
+++ b/tests/unit/test_warnings_serializer.py
@@ -1,0 +1,87 @@
+from django.test import TestCase
+
+from rest_framework import serializers
+
+from django_warnings.serializers import WarningSerializer
+from ..models import WarningsGeneratingModel
+
+
+class WarningsGeneratingSerializer(serializers.ModelSerializer):
+
+    warnings = WarningSerializer(fields=('id', 'message'))
+
+    class Meta:
+        model = WarningsGeneratingModel
+        fields = ('name', 'warnings',)
+
+
+class WarningsSerializerTest(TestCase):
+
+    def test_serializer_returns_warnings(self):
+        """
+        Serialize a model with Warnings associated to it
+        """
+        warning_model = WarningsGeneratingModel.objects.create()
+        data = WarningsGeneratingSerializer(warning_model).data
+
+        self.assertEqual(data['warnings'][0]['message'],
+                         warning_model.warning_message)
+
+    def test_serialize_queryset_returns_warnings(self):
+        """
+        Serialize a queryset of models with Warnings associated to them
+        """
+        number_of_instances = 10
+        for _ in xrange(number_of_instances):
+            WarningsGeneratingModel.objects.create()
+
+        warning_models = WarningsGeneratingModel.objects.all()
+        data = WarningsGeneratingSerializer(warning_models, many=True).data
+
+        self.assertEqual(len(data), number_of_instances)
+        for element in data:
+            self.assertEqual(element['warnings'][0]['message'],
+                             WarningsGeneratingModel.warning_message)
+
+    def test_serializer_can_contain_subject(self):
+        """
+        Use a serializer returning the `subject` the Warning object
+        """
+        class SubjectSerializer(serializers.ModelSerializer):
+            warnings = WarningSerializer(fields=('subject',))
+
+            class Meta:
+                model = WarningsGeneratingModel
+                fields = ('name', 'warnings',)
+
+        warning_model = WarningsGeneratingModel.objects.create()
+        data = SubjectSerializer(warning_model).data
+        warnings = data['warnings']
+
+        self.assertEqual(len(warnings), 1)
+        self.assertListEqual(warnings[0].keys(), ['subject'])
+        self.assertEqual(warnings[0]['subject'],
+                         'tests.models.some_warnings_method')
+
+    def test_serializer_can_contain_every_field(self):
+        """
+        Use a serializer returning the every field on the Warning object
+        """
+        all_fields = ('id', 'content_type', 'object_id', 'subject', 'message',
+                      'first_generated', 'last_generated',
+                      'acknowledged', 'last_acknowledger', 'last_acknowledged')
+
+        class FullSerializer(serializers.ModelSerializer):
+            warnings = WarningSerializer(fields=all_fields)
+
+            class Meta:
+                model = WarningsGeneratingModel
+                fields = ('name', 'warnings',)
+
+        warning_model = WarningsGeneratingModel.objects.create()
+        data = FullSerializer(warning_model).data
+        warnings = data['warnings']
+
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(set(warnings[0].keys()), set(all_fields))
+        self.assertEqual(warnings[0]['object_id'], warning_model.id)


### PR DESCRIPTION
Add a "generic" DRF serializer that can return different fields from the Warning model and can be used as a nested serializer for the main model producing warnings.

TP: https://rockabox.tpondemand.com/entity/7020
