### PR TITLE
Replace deprecated request.DATA access

### DIFF
--- a/django_warnings/views.py
+++ b/django_warnings/views.py
@@ -39,7 +39,7 @@ class WarningViewSet(ReadOnlyModelViewSet):
         Acknowledge a given Warning object. Optional `user_id` can be specified
         """
         warning = self.get_object()
-        user_id = request.DATA.get('user_id')
+        user_id = request.data.get('user_id')
 
         warning.acknowledge(user_id=user_id)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 
 setup(
     name='django-warnings',
-    version='1.2.0',
+    version='1.3.0',
     author='rockabox',
     author_email='tech@rockabox.com',
     packages=['django_warnings', 'django_warnings.migrations'],

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
 Django==1.7
 flake8
 django-nose==1.3
-djangorestframework==3.1.3
+djangorestframework==3.2.3
 coverage
 yanc
 django-json-field==0.5.7


### PR DESCRIPTION
`request.DATA` was deprecated and removed in DRF version 3.2.

